### PR TITLE
Added the buy utilities use case with tests

### DIFF
--- a/src/main/java/UseCase/UserBuyUtilities.java
+++ b/src/main/java/UseCase/UserBuyUtilities.java
@@ -1,0 +1,28 @@
+package UseCase;
+import Entity.Player;
+import Entity.Utilities;
+
+
+public class UserBuyUtilities {
+    private Player player;
+    private Utilities utility;
+
+    public UserBuyUtilities(Player player1, Utilities utility1){
+        this.player = player1;
+        this.utility = utility1;
+
+    }
+
+    public String BuyUtility(){
+        if (this.player.getMoney() >= this.utility.getPrice()) {
+            if (!this.utility.ownedByPlayer()){
+                this.player.loseMoney(this.utility.getPrice());
+                this.utility.setOwner(this.player);
+                return "Purchase Successful";
+            }
+        }
+
+        return "You don't have enough money";
+    }
+
+}

--- a/src/test/java/UseCase/UserBuyUtilitiesTest.java
+++ b/src/test/java/UseCase/UserBuyUtilitiesTest.java
@@ -1,0 +1,36 @@
+package UseCase;
+
+import Entity.Player;
+import Entity.*;
+
+
+import UseCase.UserBuyUtilities;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class UserBuyUtilitiesTest{
+
+    @Test
+    public void UserBuyUtilitiesEnoughMoney(){
+        int rolls = 10;
+        Player player1 = new Player("BOB", 1);
+        Utilities utility = new Utilities("BASE", 100);
+        UserBuyUtilities action = new UserBuyUtilities(player1, utility);
+        action.BuyUtility();
+        Assertions.assertTrue(utility.getOwner() == player1);
+
+    }
+
+    @Test
+    public void UserBuyUtilitiesNotEnoughMoney(){
+        Player player1 = new Player("BOB", 1);
+        int rolls = 10;
+        Utilities utility = new Utilities("BASE", 1600);
+        UserBuyUtilities action = new UserBuyUtilities(player1, utility);
+        action.BuyUtility();
+        Assertions.assertTrue(utility.getOwner() != player1);
+
+    }
+}
+
+


### PR DESCRIPTION
Created the buy utilities case with the tests. The buy utilities case takes in a player object with a utilities object and assigns the player as the owner of the utilities if they have enough money. If they do not, the use case returns a string that will notify the controller